### PR TITLE
Fix client.logs(stream=True) for new Docker 1.7 release

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -233,10 +233,10 @@ class Client(requests.Session):
                 break
             _, length = struct.unpack('>BxxxL', header)
             if not length:
-                break
+                continue
             data = response.raw.read(length)
             if not data:
-                break
+                continue
             yield data
 
     @property


### PR DESCRIPTION
review @theiman 

I have found that client.logs(stream=True) is broken for docker 1.7.  I looked into the docker code base and the reason is line 130 in the file daemon/logs.go:

```
// write an empty chunk of data (this is to ensure that the
// HTTP Response is sent immediatly, even if the container has
// not yet produced any data)
outStream.Write(nil)
```

Docker is now writing a nil character to the output stream before it writes any of the streaming data.  This causes the `_multiplexed_response_stream_helper` function to return immediately and not stream the output as desired. 

Solution:
What I have found is that when the nil is written by Docker the response has a valid header, it just has a length of 0.    When the container actually closes the header itself does not have a value.  This is an important distinction because it means that your break logic can purely live in the header conditional.  Every other type of check you get means that you can simply continue and wait for the next piece of data. 